### PR TITLE
Fst 126 - handle orgnr and 'personnr' as primary classification

### DIFF
--- a/src/__tests__/mock/mock-integration-configuration.ts
+++ b/src/__tests__/mock/mock-integration-configuration.ts
@@ -169,8 +169,9 @@ export const MOCK_INTEGRATION_CONFIG: IIntegrationConfiguration = {
             },
             {
                 "field": "primarklasse",
-                "valueBuildStrategy": 0,
+                "valueBuildStrategy": 1,
                 "valueBuilder": {
+                    "properties": [],
                     "value": "1class"
                 }
             },
@@ -460,8 +461,9 @@ export const MOCK_INTEGRATION_CONFIG_NOT_PUBLISHED = {
             },
             {
                 "field": "primarklasse",
-                "valueBuildStrategy": 0,
+                "valueBuildStrategy": 1,
                 "valueBuilder": {
+                    "properties": [],
                     "value": "1class"
                 }
             },
@@ -749,8 +751,9 @@ export const MOCK_INTEGRATION_CONFIG_PUBLISHED = {
             },
             {
                 "field": "primarklasse",
-                "valueBuildStrategy": 0,
+                "valueBuildStrategy": 1,
                 "valueBuilder": {
+                    "properties": [],
                     "value": "1class"
                 }
             },
@@ -1059,8 +1062,9 @@ export const MOCK_INTEGRATION_CONFIG_WITH_TAGS: IIntegrationConfiguration = {
             },
             {
                 "field": "primarklasse",
-                "valueBuildStrategy": 0,
+                "valueBuildStrategy": 1,
                 "valueBuilder": {
+                    "properties": [],
                     "value": "1class"
                 }
             },

--- a/src/features/integration/components/form/CaseForm.tsx
+++ b/src/features/integration/components/form/CaseForm.tsx
@@ -23,6 +23,8 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
 
     let errors: FieldErrors = props.errors;
     let required: boolean = props.validation;
+    let socialSecurityCode: string = 'https://beta.felleskomponent.no/arkiv/noark/klassifikasjonssystem/systemid/FNR'
+    let orgNumberCode: string = 'https://beta.felleskomponent.no/arkiv/noark/klassifikasjonssystem/systemid/ORGNR'
 
     const caseFormFields: IInputField[] = [
         {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.title", formValue: "caseData.title", required: required, error:errors.caseData?.title, value: props.activeFormData?.caseData?.title, helpText: "caseData.title"},
@@ -38,7 +40,9 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
     ]
     const classificationFormFields: IInputField[] = [
         {input: INPUT_TYPE.DROPDOWN, label: "labels.primaryClassification", value: props.watch("caseData.primaryClassification"), formValue: "caseData.primaryClassification", dropDownItems: classificationSystems, required: required, error:errors.caseData?.primaryClassification, setter: setPrimaryClassification, helpText: "caseData.classification"},
-        {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.primaryClass", value: props.watch("caseData.primaryClass"), formValue: "caseData.primaryClass", dropDownItems: primaryClass, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.class"},
+        {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.primaryClassSsNbr", value: props.activeFormData?.caseData.primaryClassSsNbr, formValue: "caseData.primaryClassSsNbr", hidden: props.watch("caseData.primaryClassification") !== socialSecurityCode, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.primaryClass"},
+        {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.primaryClassOrg", value: props.activeFormData?.caseData?.primaryClassOrg, formValue: "caseData.primaryClassOrg", hidden: props.watch("caseData.primaryClassification") !== orgNumberCode, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.primaryClass"},
+        {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.primaryClass", value: props.watch("caseData.primaryClass"), formValue: "caseData.primaryClass", hidden: props.watch("caseData.primaryClassification") === socialSecurityCode, dropDownItems: primaryClass, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.class"},
         {input: INPUT_TYPE.DROPDOWN, label: "labels.secondaryClassification", value: props.watch("caseData.secondaryClassification"), formValue: "caseData.secondaryClassification", dropDownItems: classificationSystems, required: required, error:errors.caseData?.secondaryClassification, setter: setSecondaryClassification, helpText: "caseData.classification"},
         {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.secondaryClass", value: props.watch("caseData.secondaryClass"), formValue: "caseData.secondaryClass", dropDownItems: secondaryClass, required: required, error:errors.caseData?.secondaryClass, helpText: "caseData.class"}
     ]
@@ -48,6 +52,8 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
             <FormGroup className={props.style.formControl}>
                 {caseFormFields.map((field, index) => {
                     return (
+                        field.hidden ?
+                            <div key={index}/> :
                         <Box sx={{display: 'flex'}} key={index}>
                             <Box width={'100%'}>
                                 <InputField required={field.required}
@@ -71,6 +77,8 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
                 <Divider sx={{mb: 3}}/>
                 {classificationFormFields.map((field, index) => {
                     return (
+                        field.hidden ?
+                            <div key={index}/> :
                         <Box sx={{display: 'flex'}} key={index}>
                             <Box width={'100%'}>
                                 <InputField required={field.required}

--- a/src/features/integration/components/form/CaseForm.tsx
+++ b/src/features/integration/components/form/CaseForm.tsx
@@ -29,7 +29,7 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
     const caseFormFields: IInputField[] = [
         {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.title", formValue: "caseData.title", required: required, error:errors.caseData?.title, value: props.activeFormData?.caseData?.title, helpText: "caseData.title"},
         {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.publicTitle", formValue: "caseData.publicTitle", required: required, error:errors.caseData?.publicTitle, value: props.activeFormData?.caseData?.publicTitle, helpText: "caseData.publicTitle"},
-      //  {input: INPUT_TYPE.DROPDOWN, label: "labels.type", value: props.watch("caseData.caseType"), formValue: "caseData.caseType", dropDownItems: dropdownPlaceholder, required: required, error:errors.caseData?.caseType, helpText: "caseData.caseType"},
+        //  {input: INPUT_TYPE.DROPDOWN, label: "labels.type", value: props.watch("caseData.caseType"), formValue: "caseData.caseType", dropDownItems: dropdownPlaceholder, required: required, error:errors.caseData?.caseType, helpText: "caseData.caseType"},
         {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.administrativeUnit", value: props.watch("caseData.administrativeUnit"), formValue: "caseData.administrativeUnit", dropDownItems: administrativeUnits, required: required, error:errors.caseData?.administrativeUnit, helpText: "caseData.administrativeUnit"},
         {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.responsibleCaseWorker", value: props.watch("caseData.caseWorker"), formValue: "caseData.caseWorker", dropDownItems: archiveResources, required: required, error:errors.caseData?.caseWorker, helpText: "caseData.caseWorker"},
         {input: INPUT_TYPE.DROPDOWN, label: "labels.archiveUnit", value: props.watch("caseData.archiveUnit"), formValue: "caseData.archiveUnit", dropDownItems: archiveSections, required: required, error:errors.caseData?.archiveUnit, helpText: "caseData.archiveUnit"},
@@ -40,9 +40,9 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
     ]
     const classificationFormFields: IInputField[] = [
         {input: INPUT_TYPE.DROPDOWN, label: "labels.primaryClassification", value: props.watch("caseData.primaryClassification"), formValue: "caseData.primaryClassification", dropDownItems: classificationSystems, required: required, error:errors.caseData?.primaryClassification, setter: setPrimaryClassification, helpText: "caseData.classification"},
-        {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.primaryClassSsNbr", value: props.activeFormData?.caseData.primaryClassSsNbr, formValue: "caseData.primaryClassSsNbr", hidden: props.watch("caseData.primaryClassification") !== socialSecurityCode, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.primaryClass"},
-        {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.primaryClassOrg", value: props.activeFormData?.caseData?.primaryClassOrg, formValue: "caseData.primaryClassOrg", hidden: props.watch("caseData.primaryClassification") !== orgNumberCode, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.primaryClass"},
-        {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.primaryClass", value: props.watch("caseData.primaryClass"), formValue: "caseData.primaryClass", hidden: props.watch("caseData.primaryClassification") === socialSecurityCode, dropDownItems: primaryClass, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.class"},
+        {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.primaryClassSsNbr", value: props.activeFormData?.caseData.primaryClass, formValue: "caseData.primaryClass", hidden: props.watch("caseData.primaryClassification") !== socialSecurityCode, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.class"},
+        {input: INPUT_TYPE.DROPZONE_TEXT_FIELD, label: "labels.primaryClassOrg", value: props.activeFormData?.caseData?.primaryClass, formValue: "caseData.primaryClass", hidden: props.watch("caseData.primaryClassification") !== orgNumberCode, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.class"},
+        {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.primaryClass", value: props.watch("caseData.primaryClass"), formValue: "caseData.primaryClass", hidden: props.watch("caseData.primaryClassification") === socialSecurityCode || props.watch("caseData.primaryClassification") === orgNumberCode, dropDownItems: primaryClass, required: required, error:errors.caseData?.primaryClass, helpText: "caseData.class"},
         {input: INPUT_TYPE.DROPDOWN, label: "labels.secondaryClassification", value: props.watch("caseData.secondaryClassification"), formValue: "caseData.secondaryClassification", dropDownItems: classificationSystems, required: required, error:errors.caseData?.secondaryClassification, setter: setSecondaryClassification, helpText: "caseData.classification"},
         {input: INPUT_TYPE.AUTOCOMPLETE, label: "labels.secondaryClass", value: props.watch("caseData.secondaryClass"), formValue: "caseData.secondaryClass", dropDownItems: secondaryClass, required: required, error:errors.caseData?.secondaryClass, helpText: "caseData.class"}
     ]
@@ -54,23 +54,23 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
                     return (
                         field.hidden ?
                             <div key={index}/> :
-                        <Box sx={{display: 'flex'}} key={index}>
-                            <Box width={'100%'}>
-                                <InputField required={field.required}
-                                            error={field.error}
-                                            input={field.input}
-                                            label={field.label}
-                                            value={field.value}
-                                            formValue={field.formValue}
-                                            dropdownItems={field.dropDownItems}
-                                            setter={field.setter}
-                                            {...props}
-                                />
+                            <Box sx={{display: 'flex'}} key={index}>
+                                <Box width={'100%'}>
+                                    <InputField required={field.required}
+                                                error={field.error}
+                                                input={field.input}
+                                                label={field.label}
+                                                value={field.value}
+                                                formValue={field.formValue}
+                                                dropdownItems={field.dropDownItems}
+                                                setter={field.setter}
+                                                {...props}
+                                    />
+                                </Box>
+                                <Box>
+                                    <HelpPopover popoverContent={field.helpText}/>
+                                </Box>
                             </Box>
-                            <Box>
-                                <HelpPopover popoverContent={field.helpText}/>
-                            </Box>
-                        </Box>
                     )}
                 )}
                 <Typography>{t('classification')}</Typography>
@@ -79,23 +79,23 @@ const CaseForm: React.FunctionComponent<any> = (props) => {
                     return (
                         field.hidden ?
                             <div key={index}/> :
-                        <Box sx={{display: 'flex'}} key={index}>
-                            <Box width={'100%'}>
-                                <InputField required={field.required}
-                                            error={field.error}
-                                            input={field.input}
-                                            label={field.label}
-                                            value={field.value}
-                                            formValue={field.formValue}
-                                            dropdownItems={field.dropDownItems}
-                                            setter={field.setter}
-                                            {...props}
-                                />
+                            <Box sx={{display: 'flex'}} key={index}>
+                                <Box width={'100%'}>
+                                    <InputField required={field.required}
+                                                error={field.error}
+                                                input={field.input}
+                                                label={field.label}
+                                                value={field.value}
+                                                formValue={field.formValue}
+                                                dropdownItems={field.dropDownItems}
+                                                setter={field.setter}
+                                                {...props}
+                                    />
+                                </Box>
+                                <Box>
+                                    <HelpPopover popoverContent={field.helpText}/>
+                                </Box>
                             </Box>
-                            <Box>
-                                <HelpPopover popoverContent={field.helpText}/>
-                            </Box>
-                        </Box>
                     )}
                 )}
             </FormGroup>

--- a/src/features/integration/defaults/DefaultValues.ts
+++ b/src/features/integration/defaults/DefaultValues.ts
@@ -28,6 +28,8 @@ export const defaultValues: IFormData = {
         primaryClassification: '',
         secondaryClassification: '',
         primaryClass: '',
+        primaryClassSsNbr: '',
+        primaryClassOrg: '',
         secondaryClass: ''
     },
     recordData: {

--- a/src/features/integration/types/Form/CaseData.ts
+++ b/src/features/integration/types/Form/CaseData.ts
@@ -14,5 +14,7 @@ export default interface ICaseData {
     primaryClassification?: string;
     secondaryClassification?: string;
     primaryClass?: string;
+    primaryClassSsNbr?: string;
+    primaryClassOrg?: string;
     secondaryClass?: string;
 }

--- a/src/features/util/ToFormData.ts
+++ b/src/features/util/ToFormData.ts
@@ -26,7 +26,7 @@ export function toFormData(data: IIntegrationConfiguration): IFormData {
             caseWorker: fieldToString(data.caseConfiguration, 'saksansvarlig'),
             primaryClassification: fieldToString(data.caseConfiguration, 'primarordningsprinsipp', true),
             secondaryClassification: fieldToString(data.caseConfiguration, 'sekundarordningsprinsipp', true),
-            primaryClass: fieldToString(data.caseConfiguration, 'primarklasse'),
+            primaryClass: fieldToString(data.caseConfiguration, 'primarklasse', true),
             secondaryClass: fieldToString(data.caseConfiguration, 'sekundarklasse')
         },
         recordData: {

--- a/src/features/util/ToIntegrationConfiguration.ts
+++ b/src/features/util/ToIntegrationConfiguration.ts
@@ -101,10 +101,8 @@ export function toIntegrationConfiguration(data: IFormData, id?: string): IInteg
                     },
                     {
                         field: "primarklasse",
-                        valueBuildStrategy: VALUE_BUILDER_STRATEGY.FIXED_ARCHIVE_CODE_VALUE,
-                        valueBuilder: {
-                            value: data.caseData?.primaryClass
-                        }
+                        valueBuildStrategy: VALUE_BUILDER_STRATEGY.COMBINE_STRING_VALUE,
+                        valueBuilder: createValueBuilder(data.caseData?.primaryClass)
                     },
                     {
                         field: "sekundarklasse",

--- a/src/features/util/locale/en.json
+++ b/src/features/util/locale/en.json
@@ -149,6 +149,8 @@
             "primaryClassification": "Primary classification",
             "secondaryClassification": "Secondary classification",
             "primaryClass": "Primary class",
+            "primaryClassOrg": "Primary class (organisation number)",
+            "primaryClassSsNbr": "Primary class (social security number or D-number)",
             "secondaryClass": "Secondary class",
             "type": "Type",
             "recordStatus": "Status",

--- a/src/features/util/locale/no.json
+++ b/src/features/util/locale/no.json
@@ -149,6 +149,8 @@
             "primaryClassification": "Primær ordningsprinsipp",
             "secondaryClassification": "Sekundær ordningsprinsipp",
             "primaryClass": "Primærklasse",
+            "primaryClassOrg": "Primærklasse (organisasjonsnummer)",
+            "primaryClassSsNbr": "Primærklasse (offentlignummer)",
             "secondaryClass": "Sekundærklasse",
             "type": "Type",
             "recordStatus": "Status",
@@ -175,18 +177,18 @@
                 "collection":"På samlesak",
                 "collectionDesc":"Innsendt skjema skal leveres til en forhåndsdefinert samlesak. Her må du opplyse om saksnummer"
             },
-            "applicantOptions": {                
+            "applicantOptions": {
                 "individual":"Privatperson",
                 "organisation":"Organisasjon"
             },
-            "sourceApplicationIntegrations": { 
+            "sourceApplicationIntegrations": {
                 "VIK014": "Søknad om reservasjon av skoleplass",
                 "VIK036": "Søknad til kombinasjonsprogram",
                 "VIK108": "Søknad om TT-kort",
                 "VIK132": "Samtykke - fotografering/video/lyd"
             },
-            "sourceApplications": { 
-                "label": "ACOS" 
+            "sourceApplications": {
+                "label": "ACOS"
             }
         }
     },

--- a/src/features/util/locale/noNn.json
+++ b/src/features/util/locale/noNn.json
@@ -147,6 +147,8 @@
             "primaryClassification": "Primær ordningsprinsipp",
             "secondaryClassification": "Sekundær ordningsprinsipp",
             "primaryClass": "Primærklasse",
+            "primaryClassOrg": "Primærklasse (organisasjonsnummer)",
+            "primaryClassSsNbr": "Primærklasse (offentlignummer)",
             "secondaryClass": "Sekundærklasse",
             "type": "Type",
             "recordStatus": "Status",


### PR DESCRIPTION
When choosing 'orgnr' or 'fødselsnr' as 'primærordningsprinsipp' we want to be able to use data from form to fill 'primærklasse'

Changes are made so that selecting those two as primær ordningsprinsipp will change the input field for primærklasse from a dropdown select menu with 'kodeverk' from elements, it will be a drag and drop text field, allowing the user to drag data from selected form into the field.